### PR TITLE
fix: refresh BLE device before each connection attempt

### DIFF
--- a/custom_components/nissan_leaf_obd_ble/coordinator.py
+++ b/custom_components/nissan_leaf_obd_ble/coordinator.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
+from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth.api import async_address_present
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -70,6 +71,15 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
             if self.options.get("cache_values", False):
                 return self._cache_data
             return {}
+
+        # Refresh the BLE device before connecting. The object captured at setup
+        # becomes stale after a disconnect; bleak_retry_connector needs fresh
+        # advertisement data to reliably re-establish the GATT connection.
+        ble_device = bluetooth.async_ble_device_from_address(
+            self.hass, self._address.upper(), connectable=True
+        )
+        if ble_device:
+            self.api._ble_device = ble_device
 
         try:
             new_data = await self.api.async_get_data(self.options)


### PR DESCRIPTION
## Problem

After a GATT disconnect (error 133), the integration fails to reconnect even when the device is still advertising and visible to BLE scanners. A manual integration reload is required to restore connectivity.

## Root cause

`NissanLeafObdBleApiClient` stores the `ble_device` object once at construction time (in `async_setup_entry`). After a disconnect, `bleak_retry_connector` uses this stale object to reconnect. On Linux/BlueZ, the stale device lacks fresh advertisement data (RSSI, service UUIDs, etc.) which `establish_connection` relies on for reliable reconnection.

## Fix

In `_async_update_data`, fetch a fresh `BLEDevice` from HA's bluetooth stack using `bluetooth.async_ble_device_from_address` before each `async_get_data` call. Since `async_get_data` already opens a new GATT connection on every poll, this ensures the connection attempt always uses current advertisement data.

## Testing

Reproduced by observing GATT error 133 in logs followed by repeated `UpdateFailed` cycles. After this fix, the integration reconnects automatically on the next poll without requiring a manual reload.