### PR TITLE
fix: recover from hung BLE fetch so advert wakeups work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pythonenv*
 venv
 .venv
 _new_package_repo/
+.DS_Store

--- a/custom_components/nissan_leaf_obd_ble/__init__.py
+++ b/custom_components/nissan_leaf_obd_ble/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.typing import ConfigType
 from py_nissan_leaf_obd_ble import NissanLeafObdBleApiClient
 from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
 from .coordinator import NissanLeafObdBleDataUpdateCoordinator
+from ._debug_agent import agent_log, set_debug_log_config_dir
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -32,6 +33,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})
         _LOGGER.info(STARTUP_MESSAGE)
+
+    # Debug NDJSON: primary path is <config>/nissan_leaf_debug_67a564.ndjson
+    set_debug_log_config_dir(hass.config.config_dir)
 
     address: str = entry.data[CONF_ADDRESS]
     ble_device = bluetooth.async_ble_device_from_address(
@@ -52,6 +56,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    async def _run_advert_wakeup() -> None:
+        # #region agent log
+        import time as _time_monotonic
+
+        t0 = _time_monotonic.monotonic()
+        agent_log(
+            "__init__:_run_advert_wakeup",
+            "task_start",
+            {"address": address},
+            "H1",
+        )
+        try:
+            await coordinator.async_request_refresh()
+        except Exception as err:  # noqa: BLE001
+            agent_log(
+                "__init__:_run_advert_wakeup",
+                "task_exception",
+                {"err_type": type(err).__name__, "err": str(err)[:200]},
+                "H3",
+            )
+            raise
+        dt = _time_monotonic.monotonic() - t0
+        agent_log(
+            "__init__:_run_advert_wakeup",
+            "after_async_request_refresh",
+            {"seconds": round(dt, 4)},
+            "H1",
+        )
+        # #endregion
+
     @callback
     def _async_specific_device_found(
         service_info: bluetooth.BluetoothServiceInfoBleak,
@@ -59,8 +93,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     ) -> None:
         """Handle re-discovery of the device."""
         _LOGGER.debug("New service_info: %s - %s", service_info, change)
+        # #region agent log
+        agent_log(
+            "__init__:_async_specific_device_found",
+            "callback_fired",
+            {"change": str(change)},
+            "H3",
+        )
+        # #endregion
         # have just discovered the device is back in range - ping the coordinator to update immediately
-        hass.async_create_task(coordinator.async_request_refresh())
+        hass.async_create_task(_run_advert_wakeup())
 
     # stuff to do when cleaning up
     entry.async_on_unload(

--- a/custom_components/nissan_leaf_obd_ble/_debug_agent.py
+++ b/custom_components/nissan_leaf_obd_ble/_debug_agent.py
@@ -1,0 +1,74 @@
+"""Folded debug logging for agent session 67a564. Remove after confirmed fix."""
+import json
+import logging
+import time
+from pathlib import Path
+
+_LOGGER = logging.getLogger("custom_components.nissan_leaf_obd_ble")
+
+# Set from async_setup_entry (HA config dir is writable in Docker/Core/supervised).
+_config_dir: str | None = None
+_warned_primary: bool = False
+
+# Try project .cursor path when HA runs on same machine as this repo.
+_WORKSPACE_LOG = "/Users/paulbutterworth/Projects/nissan_leaf/.cursor/debug-67a564.log"
+_FALLBACK_LOG = str(Path(__file__).resolve().parent / "debug-67a564-fallback.log")
+
+
+def set_debug_log_config_dir(config_dir: str) -> None:
+    """Call once at integration setup so logs land under the HA configuration directory."""
+    global _config_dir
+    _config_dir = config_dir
+
+
+def _candidate_paths() -> list[str]:
+    paths: list[str] = []
+    if _config_dir:
+        paths.append(str(Path(_config_dir) / "nissan_leaf_debug_67a564.ndjson"))
+    paths.append(_WORKSPACE_LOG)
+    paths.append(_FALLBACK_LOG)
+    return paths
+
+
+def agent_log(location: str, message: str, data: dict, hypothesis_id: str) -> None:
+    # #region agent log
+    global _warned_primary
+    line = (
+        json.dumps(
+            {
+                "sessionId": "67a564",
+                "location": location,
+                "message": message,
+                "data": data,
+                "timestamp": int(time.time() * 1000),
+                "hypothesisId": hypothesis_id,
+            },
+            default=str,
+        )
+        + "\n"
+    )
+    wrote_any = False
+    first_path: str | None = None
+    for path in _candidate_paths():
+        try:
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line)
+            wrote_any = True
+            if first_path is None:
+                first_path = path
+        except OSError:
+            continue
+    if wrote_any and first_path and not _warned_primary:
+        _warned_primary = True
+        _LOGGER.warning(
+            "Debug session 67a564: writing NDJSON to %s (and any other writable paths)",
+            first_path,
+        )
+    if not wrote_any and not _warned_primary:
+        _warned_primary = True
+        _LOGGER.warning(
+            "Debug session 67a564: could not write NDJSON (tried HA config dir, workspace, "
+            "and custom_components). Check permissions."
+        )
+    # #endregion

--- a/custom_components/nissan_leaf_obd_ble/coordinator.py
+++ b/custom_components/nissan_leaf_obd_ble/coordinator.py
@@ -1,5 +1,6 @@
 """Coodinator for Nissan Leaf OBD BLE."""
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
@@ -10,6 +11,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from py_nissan_leaf_obd_ble import NissanLeafObdBleApiClient
 from .const import DOMAIN
+from ._debug_agent import agent_log
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +34,9 @@ DEFAULT_FAST_POLL = 10  # pick sane defaults for your integration
 DEFAULT_SLOW_POLL = 300
 DEFAULT_XS_POLL = 3600
 DEFAULT_CACHE_VALUES = True
+# Cap BLE read duration so HA's request_refresh debouncer lock is not held forever;
+# otherwise BLE advertisements trigger async_request_refresh() but it no-ops (~70ms).
+DEFAULT_FETCH_TIMEOUT = 90
 
 
 class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
@@ -55,10 +60,26 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
+        # #region agent log
+        agent_log(
+            "coordinator:_async_update_data",
+            "enter",
+            {"address": self._address},
+            "H2_H4",
+        )
+        # #endregion
 
         # Check if the device is still available
         _LOGGER.debug("Check if the device is still available to connect")
         available = async_address_present(self.hass, self._address, connectable=True)
+        # #region agent log
+        agent_log(
+            "coordinator:_async_update_data",
+            "address_present",
+            {"available": available},
+            "H2",
+        )
+        # #endregion
         if not available:
             # Device out of range? Switch to active polling interval for when it reappears
             _LOGGER.debug("Car out of range? Switch to extra slow polling")
@@ -72,7 +93,29 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
             return {}
 
         try:
-            new_data = await self.api.async_get_data(self.options)
+            # #region agent log
+            agent_log(
+                "coordinator:_async_update_data",
+                "before_async_get_data",
+                {},
+                "H4",
+            )
+            # #endregion
+            new_data = await asyncio.wait_for(
+                self.api.async_get_data(self.options),
+                timeout=self._fetch_timeout,
+            )
+            # #region agent log
+            agent_log(
+                "coordinator:_async_update_data",
+                "after_async_get_data",
+                {
+                    "new_data_len": len(new_data) if new_data is not None else None,
+                    "is_none": new_data is None,
+                },
+                "H4_H5",
+            )
+            # #endregion
             if new_data is None:
                 raise UpdateFailed("Failed to connect to OBD device")
             if len(new_data) == 0:
@@ -88,6 +131,18 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
                     "Car is on, polling: interval = %s",
                     self.update_interval,
                 )
+        except TimeoutError as err:
+            # #region agent log
+            agent_log(
+                "coordinator:_async_update_data",
+                "fetch_timeout",
+                {"timeout_s": self._fetch_timeout},
+                "post-fix",
+            )
+            # #endregion
+            raise UpdateFailed(
+                f"BLE fetch timed out after {self._fetch_timeout}s"
+            ) from err
         except Exception as err:
             raise UpdateFailed(f"Unable to fetch data: {err}") from err
         else:
@@ -109,3 +164,6 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
         self._slow_poll_interval = options.get("slow_poll", DEFAULT_SLOW_POLL)
         self._xs_poll_interval = options.get("xs_poll", DEFAULT_XS_POLL)
         self._cache_values = options.get("cache_values", DEFAULT_CACHE_VALUES)
+        self._fetch_timeout = float(
+            options.get("fetch_timeout", DEFAULT_FETCH_TIMEOUT)
+        )


### PR DESCRIPTION
DataUpdateCoordinator.async_request_refresh() uses a debouncer lock held for the entire BLE read. When async_get_data never returned, the lock stayed held and subsequent advertisement callbacks logged but did not trigger updates (debouncer returned in ~70ms with no refresh).

- Wrap async_get_data in asyncio.wait_for with default 90s timeout (override via options fetch_timeout when exposed in config).
- On timeout, raise UpdateFailed and log agent NDJSON fetch_timeout.
- Register debug NDJSON under hass.config.config_dir plus optional paths; advert wakeup task logs debouncer duration for diagnosis.
- Ignore .DS_Store in git.