### PR TITLE
feat: add UUID configuration step to initial setup flow

### DIFF
--- a/custom_components/nissan_leaf_obd_ble/config_flow.py
+++ b/custom_components/nissan_leaf_obd_ble/config_flow.py
@@ -43,6 +43,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
+        self._selected_device: BluetoothServiceInfoBleak | None = None
 
     @staticmethod
     @callback
@@ -73,17 +74,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
             discovery_info = self._discovered_devices[address]
-            local_name = discovery_info.name
             await self.async_set_unique_id(
                 discovery_info.address, raise_on_progress=False
             )
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(
-                title=local_name,
-                data={
-                    CONF_ADDRESS: discovery_info.address,
-                },
-            )
+            self._selected_device = discovery_info
+            return await self.async_step_configure()
 
         if discovery := self._discovery_info:
             self._discovered_devices[discovery.address] = discovery
@@ -118,6 +114,36 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=data_schema,
             errors=errors,
+        )
+
+    async def async_step_configure(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
+        """Handle UUID configuration step."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._selected_device.name,
+                data={CONF_ADDRESS: self._selected_device.address},
+                options=user_input,
+            )
+        return self.async_show_form(
+            step_id="configure",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SERVICE_UUID,
+                        default=DEFAULT_SERVICE_UUID,
+                    ): str,
+                    vol.Optional(
+                        CONF_CHARACTERISTIC_UUID_READ,
+                        default=DEFAULT_CHARACTERISTIC_UUID_READ,
+                    ): str,
+                    vol.Optional(
+                        CONF_CHARACTERISTIC_UUID_WRITE,
+                        default=DEFAULT_CHARACTERISTIC_UUID_WRITE,
+                    ): str,
+                }
+            ),
         )
 
 

--- a/custom_components/nissan_leaf_obd_ble/strings.json
+++ b/custom_components/nissan_leaf_obd_ble/strings.json
@@ -1,4 +1,22 @@
 {
+  "config": {
+    "step": {
+      "configure": {
+        "title": "Configure BLE UUIDs",
+        "description": "Leave defaults unless your OBD dongle uses non-standard GATT UUIDs.",
+        "data": {
+          "service_uuid": "BLE service UUID",
+          "characteristic_uuid_read": "BLE read characteristic UUID",
+          "characteristic_uuid_write": "BLE write characteristic UUID"
+        },
+        "data_description": {
+          "service_uuid": "GATT service UUID used to connect to the OBD BLE dongle.",
+          "characteristic_uuid_read": "GATT characteristic UUID for receiving data from the dongle.",
+          "characteristic_uuid_write": "GATT characteristic UUID for sending commands to the dongle."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/nissan_leaf_obd_ble/translations/en.json
+++ b/custom_components/nissan_leaf_obd_ble/translations/en.json
@@ -1,4 +1,22 @@
 {
+  "config": {
+    "step": {
+      "configure": {
+        "title": "Configure BLE UUIDs",
+        "description": "Leave defaults unless your OBD dongle uses non-standard GATT UUIDs.",
+        "data": {
+          "service_uuid": "BLE service UUID",
+          "characteristic_uuid_read": "BLE read characteristic UUID",
+          "characteristic_uuid_write": "BLE write characteristic UUID"
+        },
+        "data_description": {
+          "service_uuid": "GATT service UUID used to connect to the OBD BLE dongle.",
+          "characteristic_uuid_read": "GATT characteristic UUID for receiving data from the dongle.",
+          "characteristic_uuid_write": "GATT characteristic UUID for sending commands to the dongle."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION
## Summary

- Adds a second step (`configure`) to the config flow so users can supply custom GATT UUIDs (service UUID, read/write characteristic UUIDs) when first adding the integration
- UUID fields are pre-filled with the existing defaults, so users with standard LeLink2 dongles can just click through without any changes
- UUIDs are stored in `entry.options` from the start, consistent with how they are stored when changed via the existing Options flow

Closes #11.

## Notes on restart requirement

UUID changes via the Options flow already take effect on the next polling cycle without a HA restart — `coordinator.options` is updated immediately by the existing `update_options_listener`, and `api.async_get_data()` reads UUIDs from `options` on every call. No repair instance or restart warning was added.

## Test plan

- [ ] Add the integration from scratch — setup flow should present a "Configure BLE UUIDs" screen after device selection, with defaults pre-filled
- [ ] Complete setup with default UUIDs — integration behaves exactly as before
- [ ] Complete setup with custom UUIDs — `entry.options` contains the custom UUIDs immediately; no Options flow visit required
- [ ] Change UUIDs via Options flow — confirm changes apply on the next poll without a HA restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)