### PR TITLE
Add OBD command and decoder override system (v0.4.0b1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,105 @@ Nissan Leaf CAN bus
 
 ---
 
+## Overriding OBD Commands and Decoders
+
+Different Nissan Leaf generations and trim levels use different OBD PIDs and message formats. Rather than waiting for a new package release, you can override any command directly in your Home Assistant config directory.
+
+### Quick start
+
+Create the file `config/custom_components/nissan_leaf_obd_ble/overrides.yaml`. Restart Home Assistant (or reload the integration) for changes to take effect.
+
+### overrides.yaml format
+
+Top-level keys are BLE device MAC addresses (upper-case). Use `_all_` to apply overrides to every Nissan Leaf config entry in your HA install.
+
+```yaml
+# config/custom_components/nissan_leaf_obd_ble/overrides.yaml
+
+_all_:                          # applies to every Leaf instance
+  commands:
+    ambient_temp:
+      command: "0322115e"       # replace the PID; keeps the built-in decoder
+
+DC:0D:30:AA:BB:CC:              # applies only to this BLE address
+  commands:
+
+    # Change the scale factor for the 12V battery voltage reading
+    bat_12v_voltage:
+      decoder:
+        type: linear_scale
+        byte_offset: 3
+        scale: 0.1
+
+    # Add a completely new sensor not in the default set
+    hv_charger_temp:
+      command: "03221299"
+      header: "797"
+      bytes: 4
+      decoder:
+        type: linear_scale
+        byte_offset: 3
+        scale: 0.5
+        offset: -40.0
+      sensor:                   # HA entity metadata (required for new commands)
+        name: "HV Charger Temperature"
+        unit: "°C"
+        device_class: temperature
+        state_class: measurement
+        icon: "mdi:thermometer"
+        precision: 1
+
+    # Skip a command entirely (e.g. one that causes issues on your model)
+    unknown:
+      enabled: false
+```
+
+Any field you omit inherits from the built-in definition. You only need to specify what changes.
+
+### Supported decoder types
+
+| Type | Required fields | Optional fields | Description |
+|---|---|---|---|
+| `linear_scale` | `byte_offset` | `scale` (default 1.0), `offset` (default 0.0) | `value = data[byte_offset] * scale + offset` |
+| `multi_byte_int` | `byte_start`, `byte_end` | `signed` (false), `byte_order` (big), `scale`, `offset` | `int.from_bytes(data[start:end])` then scale |
+| `struct_unpack` | `format`, `byte_start`, `byte_end` | `scale`, `offset` | `struct.unpack(fmt, data[start:end])[0]` then scale |
+| `lookup` | `byte_offset`, `values` | `default` | Map byte value → string via a dict |
+| `bit_flag` | `byte_offset`, `bit_mask` | — | `(data[byte_offset] & bit_mask) == bit_mask` → bool |
+| `equality` | `byte_offset`, `value` | — | `data[byte_offset] == value` → bool |
+| `multi_field` | `fields` (list of sub-specs) | — | Runs each field's sub-spec; returns a merged dict |
+| `python` | `function` | — | Calls a named function from `decoders.py` (see below) |
+
+### Python escape hatch
+
+For decoders too complex for YAML templates (e.g. multi-step bit manipulation across many bytes), you can write a Python function instead.
+
+Create `config/custom_components/nissan_leaf_obd_ble/decoders.py` alongside `overrides.yaml`:
+
+```python
+# config/custom_components/nissan_leaf_obd_ble/decoders.py
+
+def my_lbc_decoder(messages):
+    d = messages[0].data
+    soc = int.from_bytes(d[33:36], 'big') * 0.0001
+    health = int.from_bytes(d[30:32], 'big') / 102.4
+    return {"state_of_charge": soc, "hv_battery_health": health}
+```
+
+Then reference the function in `overrides.yaml`:
+
+```yaml
+DC:0D:30:AA:BB:CC:
+  commands:
+    lbc:
+      decoder:
+        type: python
+        function: my_lbc_decoder
+```
+
+The module is loaded once when the integration starts. Any errors during loading or in function lookups are reported in the HA log.
+
+---
+
 ## Troubleshooting
 
 **The integration can't find my LeLink2 adapter**

--- a/custom_components/nissan_leaf_obd_ble/__init__.py
+++ b/custom_components/nissan_leaf_obd_ble/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.typing import ConfigType
 from py_nissan_leaf_obd_ble import NissanLeafObdBleApiClient
 from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
 from .coordinator import NissanLeafObdBleDataUpdateCoordinator
+from .overrides import load_overrides
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -43,8 +44,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
     api = NissanLeafObdBleApiClient(ble_device)
+
+    extra_commands, extra_sensor_descriptions, disabled_commands = (
+        await hass.async_add_executor_job(load_overrides, hass, address)
+    )
+
     coordinator = NissanLeafObdBleDataUpdateCoordinator(
-        hass, address=address, api=api, options=entry.options or {}
+        hass,
+        address=address,
+        api=api,
+        options=entry.options or {},
+        extra_commands=extra_commands,
+        extra_sensor_descriptions=extra_sensor_descriptions,
+        disabled_commands=disabled_commands,
     )
 
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/custom_components/nissan_leaf_obd_ble/const.py
+++ b/custom_components/nissan_leaf_obd_ble/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 NAME = "Nissan Leaf OBD BLE"
 DOMAIN = "nissan_leaf_obd_ble"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.3.1"
+VERSION = "0.4.0b1"
 
 ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"
 ISSUE_URL = "https://github.com/pbutterworth/nissan-leaf-obd-ble/issues"
@@ -29,6 +29,9 @@ DEFAULT_SERVICE_UUID = "0000ffe0-0000-1000-8000-00805f9b34fb"
 DEFAULT_CHARACTERISTIC_UUID_READ = "0000ffe1-0000-1000-8000-00805f9b34fb"
 DEFAULT_CHARACTERISTIC_UUID_WRITE = "0000ffe1-0000-1000-8000-00805f9b34fb"
 
+
+OVERRIDES_FILE = "custom_components/nissan_leaf_obd_ble/overrides.yaml"
+DECODERS_MODULE_FILE = "custom_components/nissan_leaf_obd_ble/decoders.py"
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/nissan_leaf_obd_ble/coordinator.py
+++ b/custom_components/nissan_leaf_obd_ble/coordinator.py
@@ -42,7 +42,14 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
     def __init__(
-        self, hass: HomeAssistant, address: str, api: NissanLeafObdBleApiClient, options
+        self,
+        hass: HomeAssistant,
+        address: str,
+        api: NissanLeafObdBleApiClient,
+        options,
+        extra_commands=None,
+        extra_sensor_descriptions=None,
+        disabled_commands=None,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -55,6 +62,9 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
         self._address = address
         self.api = api
         self._cache_data: dict[str, Any] = {}
+        self.extra_commands = extra_commands or {}
+        self.extra_sensor_descriptions = extra_sensor_descriptions or {}
+        self.disabled_commands = disabled_commands or set()
         self.options = options
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -77,7 +87,11 @@ class NissanLeafObdBleDataUpdateCoordinator(DataUpdateCoordinator):
 
         try:
             new_data = await asyncio.wait_for(
-                self.api.async_get_data(self.options),
+                self.api.async_get_data(
+                    self.options,
+                    extra_commands=self.extra_commands or None,
+                    disabled_commands=self.disabled_commands or None,
+                ),
                 timeout=self._fetch_timeout,
             )
             if new_data is None:

--- a/custom_components/nissan_leaf_obd_ble/manifest.json
+++ b/custom_components/nissan_leaf_obd_ble/manifest.json
@@ -7,8 +7,8 @@
   "domain": "nissan_leaf_obd_ble",
   "iot_class": "local_polling",
   "name": "Nissan Leaf OBD BLE",
-  "requirements": ["py-nissan-leaf-obd-ble>=0.1.1"],
-  "version": "0.3.1",
+  "requirements": ["py-nissan-leaf-obd-ble>=0.1.2"],
+  "version": "0.4.0b1",
   "bluetooth": [
     {
       "service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb"

--- a/custom_components/nissan_leaf_obd_ble/overrides.py
+++ b/custom_components/nissan_leaf_obd_ble/overrides.py
@@ -1,0 +1,315 @@
+"""Load user-defined OBD command overrides for the Nissan Leaf integration."""
+
+import importlib.util
+import logging
+import struct
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.core import HomeAssistant
+
+from py_nissan_leaf_obd_ble.OBDCommand import OBDCommand
+from py_nissan_leaf_obd_ble.commands import leaf_commands
+
+from .const import DECODERS_MODULE_FILE, OVERRIDES_FILE
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEVICE_CLASSES: dict[str, SensorDeviceClass] = {
+    "battery": SensorDeviceClass.BATTERY,
+    "current": SensorDeviceClass.CURRENT,
+    "distance": SensorDeviceClass.DISTANCE,
+    "energy": SensorDeviceClass.ENERGY,
+    "enum": SensorDeviceClass.ENUM,
+    "power": SensorDeviceClass.POWER,
+    "pressure": SensorDeviceClass.PRESSURE,
+    "speed": SensorDeviceClass.SPEED,
+    "temperature": SensorDeviceClass.TEMPERATURE,
+    "voltage": SensorDeviceClass.VOLTAGE,
+}
+
+_STATE_CLASSES: dict[str, SensorStateClass] = {
+    "measurement": SensorStateClass.MEASUREMENT,
+    "total": SensorStateClass.TOTAL,
+    "total_increasing": SensorStateClass.TOTAL_INCREASING,
+}
+
+
+def load_overrides(
+    hass: HomeAssistant, address: str
+) -> tuple[dict[str, OBDCommand], dict[str, SensorEntityDescription], set[str]]:
+    """Return (extra_commands, extra_sensor_descriptions, disabled_commands) for a BLE address.
+
+    Reads overrides.yaml and optionally decoders.py from the integration config directory.
+    Safe to call from an executor thread (synchronous I/O only).
+    """
+    overrides_path = Path(hass.config.config_dir) / OVERRIDES_FILE
+    decoders_path = Path(hass.config.config_dir) / DECODERS_MODULE_FILE
+
+    python_module = None
+    if decoders_path.exists():
+        python_module = _load_python_module(decoders_path)
+
+    if not overrides_path.exists():
+        return {}, {}, set()
+
+    try:
+        with open(overrides_path) as f:
+            config = yaml.safe_load(f)
+    except Exception as err:
+        _LOGGER.error("Failed to load %s: %s", overrides_path, err)
+        return {}, {}, set()
+
+    if not config:
+        return {}, {}, set()
+
+    # Merge _all_ entries with address-specific entries; address-specific wins on conflict
+    command_entries: dict[str, Any] = {}
+    if "_all_" in config:
+        command_entries.update(((config["_all_"] or {}).get("commands", {})))
+    address_upper = address.upper()
+    if address_upper in config:
+        command_entries.update(((config[address_upper] or {}).get("commands", {})))
+
+    extra_commands: dict[str, OBDCommand] = {}
+    extra_sensor_descriptions: dict[str, SensorEntityDescription] = {}
+    disabled_commands: set[str] = set()
+
+    for key, entry in command_entries.items():
+        entry = entry or {}
+
+        if not entry.get("enabled", True):
+            disabled_commands.add(key)
+            continue
+
+        try:
+            cmd = _build_command(key, entry, python_module)
+        except Exception as err:
+            _LOGGER.error("Invalid override for command '%s': %s", key, err)
+            continue
+
+        extra_commands[key] = cmd
+
+        if "sensor" in entry and key not in leaf_commands:
+            try:
+                extra_sensor_descriptions.update(_build_sensor_descriptions(key, entry))
+            except Exception as err:
+                _LOGGER.error("Invalid sensor definition for command '%s': %s", key, err)
+
+    return extra_commands, extra_sensor_descriptions, disabled_commands
+
+
+def _load_python_module(path: Path):
+    """Load a Python module from a file path."""
+    try:
+        spec = importlib.util.spec_from_file_location("nissan_leaf_obd_ble_decoders", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _LOGGER.info("Loaded custom decoders from %s", path)
+        return module
+    except Exception as err:
+        _LOGGER.error("Failed to load custom decoders from %s: %s", path, err)
+        return None
+
+
+def _build_command(key: str, entry: dict, python_module) -> OBDCommand:
+    """Build an OBDCommand, inheriting unspecified fields from the base command if it exists."""
+    base = leaf_commands.get(key)
+
+    if "command" in entry:
+        command = entry["command"].encode()
+    elif base is not None:
+        command = base.command
+    else:
+        raise ValueError(f"'command' is required for new command '{key}'")
+
+    if "header" in entry:
+        header = entry["header"].encode()
+    elif base is not None:
+        header = base.header
+    else:
+        raise ValueError(f"'header' is required for new command '{key}'")
+
+    if "bytes" in entry:
+        byte_count = int(entry["bytes"])
+    elif base is not None:
+        byte_count = base.bytes
+    else:
+        raise ValueError(f"'bytes' is required for new command '{key}'")
+
+    if "decoder" in entry:
+        decoder = _build_decoder(key, entry["decoder"], python_module)
+    elif base is not None:
+        decoder = base.decode
+    else:
+        raise ValueError(f"'decoder' is required for new command '{key}'")
+
+    desc = entry.get("description", base.desc if base else key)
+
+    return OBDCommand(key, desc, command, byte_count, decoder, header)
+
+
+def _build_decoder(key: str, spec: dict, python_module) -> Callable:
+    """Build a decoder function from a YAML decoder spec dict."""
+    decoder_type = spec.get("type")
+    if not decoder_type:
+        raise ValueError(f"Decoder spec for '{key}' is missing 'type'")
+
+    if decoder_type == "linear_scale":
+        byte_offset = int(spec["byte_offset"])
+        scale = float(spec.get("scale", 1.0))
+        offset = float(spec.get("offset", 0.0))
+
+        def _linear(messages, _key=key, _off=byte_offset, _scale=scale, _add=offset):
+            return {_key: messages[0].data[_off] * _scale + _add}
+
+        return _linear
+
+    if decoder_type == "multi_byte_int":
+        byte_start = int(spec["byte_start"])
+        byte_end = int(spec["byte_end"])
+        signed = bool(spec.get("signed", False))
+        byte_order = spec.get("byte_order", "big")
+        scale = float(spec.get("scale", 1.0))
+        offset = float(spec.get("offset", 0.0))
+
+        def _multi_byte(
+            messages,
+            _key=key,
+            _start=byte_start,
+            _end=byte_end,
+            _signed=signed,
+            _order=byte_order,
+            _scale=scale,
+            _add=offset,
+        ):
+            v = int.from_bytes(messages[0].data[_start:_end], _order, signed=_signed)
+            return {_key: v * _scale + _add}
+
+        return _multi_byte
+
+    if decoder_type == "struct_unpack":
+        fmt = spec["format"]
+        byte_start = int(spec["byte_start"])
+        byte_end = int(spec["byte_end"])
+        scale = float(spec.get("scale", 1.0))
+        offset = float(spec.get("offset", 0.0))
+
+        def _struct(
+            messages,
+            _key=key,
+            _fmt=fmt,
+            _start=byte_start,
+            _end=byte_end,
+            _scale=scale,
+            _add=offset,
+        ):
+            v = struct.unpack(_fmt, messages[0].data[_start:_end])[0]
+            return {_key: v * _scale + _add}
+
+        return _struct
+
+    if decoder_type == "lookup":
+        byte_offset = int(spec["byte_offset"])
+        values = {int(k): v for k, v in spec["values"].items()}
+        default = spec.get("default")
+
+        def _lookup(messages, _key=key, _off=byte_offset, _values=values, _default=default):
+            return {_key: _values.get(messages[0].data[_off], _default)}
+
+        return _lookup
+
+    if decoder_type == "bit_flag":
+        byte_offset = int(spec["byte_offset"])
+        bit_mask = int(str(spec["bit_mask"]), 0)
+
+        def _bit_flag(messages, _key=key, _off=byte_offset, _mask=bit_mask):
+            return {_key: (messages[0].data[_off] & _mask) == _mask}
+
+        return _bit_flag
+
+    if decoder_type == "equality":
+        byte_offset = int(spec["byte_offset"])
+        value = int(str(spec["value"]), 0)
+
+        def _equality(messages, _key=key, _off=byte_offset, _val=value):
+            return {_key: messages[0].data[_off] == _val}
+
+        return _equality
+
+    if decoder_type == "multi_field":
+        fields = spec["fields"]
+        sub_decoders = [
+            _build_decoder(field["key"], field, python_module) for field in fields
+        ]
+
+        def _multi_field(messages, _subs=sub_decoders):
+            result = {}
+            for sub in _subs:
+                result.update(sub(messages))
+            return result
+
+        return _multi_field
+
+    if decoder_type == "python":
+        func_name = spec.get("function")
+        if not func_name:
+            raise ValueError(
+                f"Decoder type 'python' for '{key}' requires a 'function' name"
+            )
+        if python_module is None:
+            raise ValueError(
+                f"Decoder type 'python' for '{key}' requires "
+                f"'{DECODERS_MODULE_FILE}' to be present in the integration directory"
+            )
+        func = getattr(python_module, func_name, None)
+        if func is None:
+            raise ValueError(
+                f"Function '{func_name}' not found in '{DECODERS_MODULE_FILE}'"
+            )
+        return func
+
+    raise ValueError(f"Unknown decoder type '{decoder_type}' for command '{key}'")
+
+
+def _build_sensor_descriptions(
+    key: str, entry: dict
+) -> dict[str, SensorEntityDescription]:
+    """Build SensorEntityDescription(s) from the sensor: block of an override entry."""
+    sensor_block = entry["sensor"]
+    decoder_type = (entry.get("decoder") or {}).get("type")
+
+    if decoder_type == "multi_field":
+        if not isinstance(sensor_block, list):
+            raise ValueError(f"'sensor' must be a list for multi_field command '{key}'")
+        return {
+            field["key"]: _sensor_desc_from_block(field["key"], field)
+            for field in sensor_block
+        }
+
+    return {key: _sensor_desc_from_block(key, sensor_block)}
+
+
+def _sensor_desc_from_block(key: str, block: dict) -> SensorEntityDescription:
+    """Build a SensorEntityDescription from a sensor config block."""
+    device_class_str = block.get("device_class")
+    device_class = _DEVICE_CLASSES.get(device_class_str) if device_class_str else None
+
+    state_class_str = block.get("state_class")
+    state_class = _STATE_CLASSES.get(state_class_str) if state_class_str else None
+
+    return SensorEntityDescription(
+        key=key,
+        name=block.get("name", key),
+        native_unit_of_measurement=block.get("unit"),
+        device_class=device_class,
+        state_class=state_class,
+        suggested_display_precision=block.get("precision"),
+        icon=block.get("icon"),
+    )

--- a/custom_components/nissan_leaf_obd_ble/sensor.py
+++ b/custom_components/nissan_leaf_obd_ble/sensor.py
@@ -250,9 +250,11 @@ async def async_setup_entry(
     """Set up sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
     entities = [
-        NissanLeafObdBleSensor(coordinator, entry, sensor_desc)
-        for sensor_desc in SENSOR_TYPES
+        NissanLeafObdBleSensor(coordinator, entry, desc)
+        for desc in SENSOR_TYPES.values()
     ]
+    for desc in coordinator.extra_sensor_descriptions.values():
+        entities.append(NissanLeafObdBleSensor(coordinator, entry, desc))
     async_add_entities(entities)
 
 
@@ -263,17 +265,16 @@ class NissanLeafObdBleSensor(NissanLeafObdBleEntity, SensorEntity):
         self,
         coordinator,
         config_entry,
-        sensor: str,
+        description: SensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, config_entry)
-        self._sensor = sensor
-        self._attr_name = f"{NAME} {SENSOR_TYPES[sensor].name}"
-        self._attr_device_class = SENSOR_TYPES[sensor].device_class
-        self._attr_native_unit_of_measurement = SENSOR_TYPES[
-            sensor
-        ].native_unit_of_measurement
-        self._attr_state_class = SENSOR_TYPES[sensor].state_class
+        self._description = description
+        self._sensor = description.key
+        self._attr_name = f"{NAME} {description.name}"
+        self._attr_device_class = description.device_class
+        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._attr_state_class = description.state_class
 
     @property
     def native_value(self):
@@ -283,4 +284,4 @@ class NissanLeafObdBleSensor(NissanLeafObdBleEntity, SensorEntity):
     @property
     def icon(self):
         """Return the icon of the sensor."""
-        return SENSOR_TYPES[self._sensor].icon
+        return self._description.icon


### PR DESCRIPTION
## Summary

- Adds a user-facing override system so users can adapt OBD commands and decoders to their specific Leaf generation without modifying installed packages or waiting for a release.
- Bumps `py-nissan-leaf-obd-ble` requirement to `>=0.1.2` (which added the `extra_commands` / `disabled_commands` API).
- Version `0.3.1 → 0.4.0b1`.

## How it works

At integration startup, the coordinator loads two optional files from `config/custom_components/nissan_leaf_obd_ble/`:

- **`overrides.yaml`** — declarative overrides for existing commands (change PID bytes, header, decoder) and additions of entirely new commands. Keyed by BLE MAC address with an `_all_` wildcard.
- **`decoders.py`** — Python escape hatch for complex decoders that can't be expressed as YAML templates (e.g. multi-step bit manipulation).

Supported YAML decoder types: `linear_scale`, `multi_byte_int`, `struct_unpack`, `lookup`, `bit_flag`, `equality`, `multi_field`, `python`.

New commands with a `sensor:` block automatically get a HA sensor entity created for them.

## Files changed

| File | Change |
|---|---|
| `overrides.py` | **New.** YAML loader, decoder factory, OBDCommand builder, sensor description builder |
| `__init__.py` | Calls `load_overrides()` via executor; passes results to coordinator |
| `coordinator.py` | Accepts and stores `extra_commands`, `extra_sensor_descriptions`, `disabled_commands`; passes them to `async_get_data()` |
| `sensor.py` | `NissanLeafObdBleSensor` takes `SensorEntityDescription` directly; `async_setup_entry` adds dynamic sensors |
| `const.py` | `OVERRIDES_FILE`, `DECODERS_MODULE_FILE` constants; version bump |
| `manifest.json` | `py-nissan-leaf-obd-ble>=0.1.2`; version `0.4.0b1` |
| `README.md` | Documents override system, YAML format, decoder types, Python escape hatch |

## Test plan

- [ ] Integration starts normally with no `overrides.yaml` present (backward-compatible)
- [ ] Override an existing command PID in `overrides.yaml` and confirm the new bytes are sent to the car
- [ ] Override a decoder with `linear_scale` and verify the scaled value appears in HA
- [ ] Add a new command with a `sensor:` block and confirm the entity is created in HA
- [ ] Set `enabled: false` on a command and verify it is skipped
- [ ] Place a `decoders.py` with a custom function and confirm it is called correctly
- [ ] Confirm errors in `overrides.yaml` are logged without crashing the integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)